### PR TITLE
Change local theme installation guide to a better one

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,8 @@ Install the theme(s) locally if you for some reason can't run as a sudo user. Fe
 ```bash
 git clone https://github.com/lassekongo83/adw-gtk3.git
 cd adw-gtk3
-meson build
-DESTDIR=/home/your-username/.themes ninja -C build install
-mv ~/.themes/usr/share/themes/* ~/.themes
-rm -r ~/.themes/usr
+meson -Dprefix="${HOME}/.local" build
+ninja -C build install
 ```
 
 ### Updating the theme
@@ -60,9 +58,7 @@ sudo ninja -C build install
 For a local install:
 ```bash
 git pull
-DESTDIR=/home/your-username/.themes ninja -C build install
-mv ~/.themes/usr/share/themes/* ~/.themes
-rm -r ~/.themes/usr
+ninja -C build install
 ```
 
 ## Changing themes


### PR DESCRIPTION
This PR changes the README to show a simpler and better installation commands for local installations of the theme. It will now guide the user to use the meson def `prefix` of the project, instead of injecting the destination path to ninja and making a clobbered directory structure under `~/.themes`. This is not only for easier installation steps, but a simpler update mechanism because `ninja -C build install` can just be ran after `git pull` since the directory path is properly set when generating the ninja build files.
 
As an addition, this will guide users to install the theme into `~/.local/share/themes` for a cleaner home directory (which mirrors the `/usr` structure better)