### PR TITLE
Better menuitem contrast for some GTK3 applications like Thunar

### DIFF
--- a/gtk/src/adw-gtk3/gtk-3.0/gtk-dark.css
+++ b/gtk/src/adw-gtk3/gtk-3.0/gtk-dark.css
@@ -854,7 +854,7 @@ menu:backdrop, .menu:backdrop, .org-gnome-Builder .dzlmenubutton:backdrop, .cont
 
 menu menuitem, .menu menuitem, .org-gnome-Builder .dzlmenubutton menuitem, .org-gnome-Builder .dzlmenubutton .dzlmenubuttonitem, .context-menu menuitem { min-height: 16px; min-width: 40px; padding: 4px 6px; text-shadow: none; font-weight: normal; }
 
-menu menuitem:hover, .menu menuitem:hover, .org-gnome-Builder .dzlmenubutton menuitem:hover, .org-gnome-Builder .dzlmenubutton .dzlmenubuttonitem:hover, .context-menu menuitem:hover { background-color: #3f3f3f; }
+menu menuitem:hover, .menu menuitem:hover, .org-gnome-Builder .dzlmenubutton menuitem:hover, .org-gnome-Builder .dzlmenubutton .dzlmenubuttonitem:hover, .context-menu menuitem:hover { background-color: #3584E4; }
 
 menu menuitem:disabled, .menu menuitem:disabled, .org-gnome-Builder .dzlmenubutton menuitem:disabled, .org-gnome-Builder .dzlmenubutton .dzlmenubuttonitem:disabled, .context-menu menuitem:disabled { color: #929292; }
 
@@ -1671,7 +1671,7 @@ row.activatable:selected { color: white; }
 
 row.activatable:selected:active { background-color: #4e4e4e; }
 
-row.activatable:selected.has-open-popup, row.activatable:selected:hover { background-color: #3f3f3f; color: white; }
+row.activatable:selected.has-open-popup, row.activatable:selected:hover { background-color: #3584E4; color: white; }
 
 row.activatable:selected:backdrop { background-color: #303030; color: white; }
 


### PR DESCRIPTION
Hello @lassekongo83 !

First of all, I would like to thank you for all the hard work in creating this GTK3 theme. It really helps create a consistent look on the Linux desktop, especially as we get closer to the full adaptation of libadwaita.  

I am making this pull request in regards to switching the colors around to enhance contrast on menuitem selections (with the dark variant of adw) for some GTK3 applications. All my commit changed was 2 lines on gtk-dark.css, replacing all instances of #3f3f3f to #3584e4

Here's an example of how it looks:

Before:
![3f3f3f](https://user-images.githubusercontent.com/15715121/162276449-99515984-2030-4944-b77b-3567c6230450.png)

After:
![3584e4](https://user-images.githubusercontent.com/15715121/162276543-61211026-97ab-4c31-90ea-f849a5c1f0ef.png)


I know this would mean that it would not be completely true to becoming a full-port of the libadwaita theme, but I think it helps with functionality of the theme in everyday use.

Again thank you very much for all the hard work, wishing that all of you are well. 
