### PR TITLE
Add meson flag for dark theme

### DIFF
--- a/gtk/src/adw-gtk3/gtk-3.0/meson.build
+++ b/gtk/src/adw-gtk3/gtk-3.0/meson.build
@@ -6,10 +6,16 @@ install_subdir('assets', install_dir : gtk3_dir, strip_directory : false)
 # theme sources .scss files
 
 # The files that need to be compiled
-gtk3_scss_sources = [
-  'gtk',
-  'gtk-dark',
-]
+if get_option('dark')
+  gtk3_scss_sources = [
+    'gtk',
+    'gtk-dark',
+  ]
+else
+  gtk3_scss_sources = [
+    'gtk',
+  ]
+endif
 
 # Dependencies of the files that need to be compiled
 gtk3_scss_dependencies = [

--- a/gtk/src/meson.build
+++ b/gtk/src/meson.build
@@ -1,2 +1,5 @@
 subdir('adw-gtk3')
-subdir('adw-gtk3-dark')
+
+if get_option('dark')
+    subdir('adw-gtk3-dark')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('dark', type: 'boolean', value: true, description: 'Enable dark mode')


### PR DESCRIPTION
By default, dark theme is enabled. However, if a user did not want to install the dark theme, when running Meson, a user can either use

```sh
# Local Installation
$ meson -Dprefix="${HOME}/.local" -Ddark=false build
```

or

```sh
# System Installation
meson -Ddark=false build
```

When ran with no `-Ddark` argument, the default value is set to true, thus meaning that the dark theme is by default generated, and it requires the user to explicitly use the flag to disable it

The `-Ddark=false` flag disables the generation of the adw-gtk3 dark theme. adw-gtk3-dark will not be installed, nor will gtk-dark.css.