### PR TITLE
add VSCode theme to list of adwaita-like themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Adw-gtk3 and libadwaita can be customized with GTK named colors. See [adw-colors
 - **Kvantum:** https://github.com/GabePoel/KvLibadwaita
 - **Firefox:** https://github.com/rafaelmardojai/firefox-gnome-theme
 - **Steam:** https://github.com/tkashkin/Adwaita-for-Steam
+- **VSCode:** https://github.com/piousdeer/vscode-adwaita
 <div align="center">
 
 ## How to uninstall the theme(s)


### PR DESCRIPTION
Added [this](https://github.com/piousdeer/vscode-adwaita) VSCode theme to the "For more consistency" section of the README file.