### PR TITLE
Replace :inconsistent with :indeterminate

### DIFF
--- a/gtk/src/adw-gtk3/gtk-3.0/_drawing.scss
+++ b/gtk/src/adw-gtk3/gtk-3.0/_drawing.scss
@@ -489,7 +489,7 @@ $focus_border_color: gtkalpha($accent_color, 0.5);
   }
 
   @if $t==hover {
-    &:not(:checked):not(:inconsistent) { border-color: $trough_hover_color; }
+    &:not(:checked):not(:indeterminate) { border-color: $trough_hover_color; }
   }
 
   @if $t==active {


### PR DESCRIPTION
GTK 3 applications show a deprecation warning for :inconsistent. This change makes the warning go away.

```
Gtk-WARNING **: 16:35:34.882: Theme parsing error: gtk.css:1126:117: The :inconsistent pseudo-class is deprecated. Use :indeterminate instead.
```