### PR TITLE
Using pacman to install on Arch in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ gsettings set org.gnome.desktop.interface gtk-theme 'Adwaita' && gsettings set o
 These are maintained by contributors.
 
 * **Fedora:** `dnf install adw-gtk3-theme`
-* **AUR:** https://aur.archlinux.org/packages/adw-gtk3-git/
+* **Arch:** `pacman -S adw-gtk-theme`
 * **Manjaro**: `pamac install adw-gtk3`
 * **Debian**: https://gitlab.com/julianfairfax/package-repo#how-to-add-repository-for-debian-based-linux-distributions
 


### PR DESCRIPTION
I found that [Arch added `adw-gtk3` to the Extra repository](https://archlinux.org/packages/extra/any/adw-gtk-theme/), so we can install it via pacman now.