### PR TITLE
Adjust selection background color in chromium

### DIFF
--- a/src/sass/gtk4/libadwaita-tweaks.scss
+++ b/src/sass/gtk4/libadwaita-tweaks.scss
@@ -65,7 +65,7 @@ headerbar {
 
   selection {
     &, &:focus {
-      background-color: var(--accent-bg-color);
+      background-color: color-mix(in srgb, var(--accent-bg-color) 30%, transparent);
       color: var(--accent-fg-color);
     }
   }


### PR DESCRIPTION
This mixes the selection background color in chromium (address bar) rather than just using the accent-bg-color, which is more inline with Adwaita.

Stock Adwaita legacy theme:

![Screenshot From 2025-06-18 13-00-21](https://github.com/user-attachments/assets/e207ba33-21ac-4efd-ab07-2509c63f92e2)

Current adw-gtk3 theme:

![Screenshot From 2025-06-18 13-01-51](https://github.com/user-attachments/assets/5f509336-fd81-4d8e-9fb3-67dfc4092b38)

Modified adw-gtk3 theme:

![Screenshot From 2025-06-18 13-01-09](https://github.com/user-attachments/assets/05d907ad-a270-4afd-8517-5c8c5ac3415a)
