### PR TITLE
revert(libadwaita-tweaks): remove hard-coded --accent-bg-color

### DIFF
--- a/src/sass/gtk4/libadwaita-tweaks.scss
+++ b/src/sass/gtk4/libadwaita-tweaks.scss
@@ -21,7 +21,7 @@
   --accent-purple: #9141ac;
   --accent-slate: #6f8396;
 
-  --accent-bg-color: var(--accent-blue);
+  --accent-bg-color: @accent_bg_color;
   --accent-fg-color: @accent_fg_color;
 
   --window-bg-color: @window_bg_color;


### PR DESCRIPTION
Revert 385a900628644dc81fa4942ac848a765229be93a

This was introduced in a slightly different shape to fix #272, but it prevents setting `@accent_bg_color` via `XDG_CONFIG_HOME/gtk-4.0/gtk.css`.

I also cannot seem to reproduce the original issue that lead to the tweak.